### PR TITLE
Added support to allow v8 contexts to be created/used across multiple goroutines

### DIFF
--- a/v8wrap.cc
+++ b/v8wrap.cc
@@ -40,6 +40,7 @@ from_json(std::string str) {
 
 v8::Handle<v8::Value>
 _go_call(const v8::Arguments& args) {
+  v8::Locker v8Locker;
   uint32_t id = args[0]->ToUint32()->Value();
   v8::String::Utf8Value name(args[1]);
   v8::String::Utf8Value argv(args[2]);
@@ -56,6 +57,7 @@ _go_call(const v8::Arguments& args) {
 class V8Context {
 public:
   V8Context() {
+    v8::Locker v8Locker;
     v8::HandleScope scope;
     global = v8::ObjectTemplate::New();
     global->Set(v8::String::New("_go_call"),
@@ -132,6 +134,7 @@ report_exception(v8::TryCatch& try_catch) {
 
 char*
 v8_execute(void *ctx, char* source) {
+  v8::Locker v8Locker;
   V8Context *context = static_cast<V8Context *>(ctx);
   v8::HandleScope scope;
   v8::TryCatch try_catch;


### PR DESCRIPTION
Introduces v8:Locker when making calls into the v8 library from the wrapper.  Specifically, this is required for any cross thread/goroutine access of v8 regardless of context. The lockers effectively serialize v8 eval calls to the v8 processor.  V8 does have the ability to create completely independent contexts using V8:Isolates, and might be interesting to expose that functionality in the future.
- Added the lockers to context constructor, execute method, and callback.
